### PR TITLE
Update zombieownership.sol

### DIFF
--- a/lesson-5/chapter-6/zombieownership.sol
+++ b/lesson-5/chapter-6/zombieownership.sol
@@ -23,7 +23,7 @@ contract ZombieOwnership is ZombieAttack, ERC721 {
   }
 
   function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
-    require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals[_tokenId] == msg.sender);
+    require ((zombieToOwner[_tokenId] == msg.sender && _from == msg.sender) || (zombieApprovals[_tokenId] == msg.sender && _to == msg.sender));
     _transfer(_from, _to, _tokenId);
   }
 


### PR DESCRIPTION
For our specified use cases, this should help in preventing honest mistakes of users of the contract.

I may invoke transferFrom(A, B, Z) and be the owner of Z, but if A is not my correct address, the code will reduce someone else's zombieCount and also emit a Transfer event that's not accurate in what it says.