### PR TITLE
Typo in ABI definition.

### DIFF
--- a/lesson-6/chapter-3/cryptozombies_abi.js
+++ b/lesson-6/chapter-3/cryptozombies_abi.js
@@ -269,6 +269,7 @@ var cryptoZombiesABI = [
       "stateMutability": "view",
       "type": "function"
     },
+    {
       "constant": false,
       "inputs": [
         {


### PR DESCRIPTION
Missing single opening bracket "{".