### PR TITLE
Accept only valid _targetDna

### DIFF
--- a/lesson-2/chapter-8/zombiefeeding.sol
+++ b/lesson-2/chapter-8/zombiefeeding.sol
@@ -5,7 +5,7 @@ contract ZombieFeeding is ZombieFactory {
   function feedAndMultiply(uint _zombieId, uint _targetDna) public {
     require(msg.sender == zombieToOwner[_zombieId]);
     Zombie storage myZombie = zombies[_zombieId];
-    _targetDna = _targetDna % dnaModulus;
+    require(_targetDna == _targetDna % dnaModulus);
     uint newDna = (myZombie.dna + _targetDna) / 2;
     _createZombie("NoName", newDna);
   }


### PR DESCRIPTION
In case _targetDna > 10**6 than we going to have new zombies with probably duplicated dna. IMHO better restrict to accept only valid dna then support invalid cases.