### PR TITLE
fix(createZombie): _name should be of reference type

### DIFF
--- a/lesson-1/chapter-7/Contract.sol
+++ b/lesson-1/chapter-7/Contract.sol
@@ -12,7 +12,7 @@ contract ZombieFactory {
 
     Zombie[] public zombies;
 
-    function createZombie(string _name, uint _dna) {
+    function createZombie(string memory _name, uint _dna) {
 
     }
 


### PR DESCRIPTION
### Motivation:

Function parameter _name should be reference type.

### Modification:

Add memory keyword to _name function argument.