### PR TITLE
Allow "now" to be a valid _isReady time

### DIFF
--- a/lesson-3/chapter-6/zombiefeeding.sol
+++ b/lesson-3/chapter-6/zombiefeeding.sol
@@ -27,7 +27,7 @@ contract ZombieFeeding is ZombieFactory {
   }
 
   function _isReady(Zombie storage _zombie) internal view returns (bool) {
-      return (_zombie.readyTime <= now);
+      return (_zombie.readyTime < now);
   }
 
   function feedAndMultiply(uint _zombieId, uint _targetDna, string _species) public {


### PR DESCRIPTION
Currently, zombies can only feed if it is *past* `now`.

Sensibly, zombies should be able to eat starting `now` (once the `cooldownTime` has completed). That is what this change accomplishes.

*P.S. `now` is no longer supported in Solidity 0.7.0. `block.timestamp` must be used instead.*