### PR TITLE
Fix some deprecated  keyword for creating interfaces

### DIFF
--- a/lesson-2/chapter-10/zombiefeeding.sol
+++ b/lesson-2/chapter-10/zombiefeeding.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.25;
 import "./zombiefactory.sol";
-contract KittyInterface {
+interface KittyInterface {
   function getKitty(uint256 _id) external view returns (
     bool isGestating,
     bool isReady,

--- a/lesson-2/chapter-11/zombiefeeding.sol
+++ b/lesson-2/chapter-11/zombiefeeding.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.25;
 import "./zombiefactory.sol";
-contract KittyInterface {
+interface KittyInterface {
   function getKitty(uint256 _id) external view returns (
     bool isGestating,
     bool isReady,

--- a/lesson-2/chapter-12/zombiefeeding.sol
+++ b/lesson-2/chapter-12/zombiefeeding.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.25;
 import "./zombiefactory.sol";
-contract KittyInterface {
+interface KittyInterface {
   function getKitty(uint256 _id) external view returns (
     bool isGestating,
     bool isReady,

--- a/lesson-2/chapter-13/zombiefeeding.sol
+++ b/lesson-2/chapter-13/zombiefeeding.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.25;
 import "./zombiefactory.sol";
-contract KittyInterface {
+interface KittyInterface {
   function getKitty(uint256 _id) external view returns (
     bool isGestating,
     bool isReady,


### PR DESCRIPTION

### Description

This pull request addresses the issue of using `contract` keyword for creating interfaces was in older versions of solidity. Now we use `interface` keyword for creating interfaces in smart contracts. i fixed 'contract' keyword to `interface` in lesson-2, chapter 10,11,12 and 13.